### PR TITLE
Fix bugs in tasklist.c

### DIFF
--- a/Sources/libcmark_gfm/tasklist.c
+++ b/Sources/libcmark_gfm/tasklist.c
@@ -17,7 +17,7 @@ char *cmark_gfm_extensions_get_tasklist_state(cmark_node *node) {
   if (!node || ((int)node->as.opaque != CMARK_TASKLIST_CHECKED && (int)node->as.opaque != CMARK_TASKLIST_NOCHECKED))
     return 0;
 
-  if ((int)node->as.opaque != CMARK_TASKLIST_CHECKED) {
+  if ((int)node->as.opaque == CMARK_TASKLIST_CHECKED) {
     return "checked";
   }
   else {
@@ -74,7 +74,8 @@ static cmark_node *open_tasklist_item(cmark_syntax_extension *self,
   cmark_node_set_syntax_extension(parent_container, self);
   cmark_parser_advance_offset(parser, (char *)input, 3, false);
 
-  if (strstr((char*)input, "[x]")) {
+  // Spec says that either upper or lower case x means completed.
+  if (strstr((char*)input, "[x]") || strstr((char*)input, "[X]")) {
     parent_container->as.opaque = (void *)CMARK_TASKLIST_CHECKED;
   } else {
     parent_container->as.opaque = (void *)CMARK_TASKLIST_NOCHECKED;


### PR DESCRIPTION
- fix check to determine whether the taskitem should report as true. (it was using wrong logic)
- spec says that either upper or lower case X is valid for marking a task as complete.